### PR TITLE
25 eng 010 cli runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "typecheck": "tsc -p . --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "report": "ts-node src/cli/report.ts"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -1,0 +1,23 @@
+// src/cli/report.ts
+import { readFile } from "fs/promises";
+import { buildReport } from "../engine/system";
+
+async function main() {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("Usage: npm run report -- <path-to-fixture.json>");
+    process.exit(1);
+  }
+  const raw = await readFile(path, "utf8");
+  const candidate = JSON.parse(raw);
+  const report = buildReport(candidate);
+  console.log(`Overall: ${report.overall}`);
+  for (const r of report.reasons) {
+    console.log(`- [${r.level}] ${r.category}: ${r.message}`);
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/cli.smoke.test.ts
+++ b/tests/cli.smoke.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import baseline from "../fixtures/baseline-2025.json";
+import { buildReport } from "../src/engine/system";
+
+describe("cli smoke via system", () => {
+  it("buildReport returns an overall", () => {
+    const res = buildReport(baseline as any);
+    expect(["PASS","WARN","FAIL"]).toContain(res.overall);
+  });
+});


### PR DESCRIPTION
Acceptance check:
`npm run report -- fixtures/baseline-2025.json` prints overall verdict and reasons.

What changed:
- `src/cli/report.ts`
- package.json script `"report"`

How I proved it:
- Ran the command locally; CI still green.

Closes #<issue-number>
